### PR TITLE
fix: address high and critical CVEs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  form-data: '>=4.0.4'
+  form-data: '>=4.0.6'
   braces: '>=3.0.3'
   cross-spawn: '>=7.0.5'
   minimatch: '>=3.1.4'
@@ -1232,8 +1232,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs.realpath@1.0.0:
@@ -3369,7 +3369,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -3908,7 +3908,7 @@ snapshots:
       decimal.js: 10.4.3
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ allowBuilds:
   sharp: true
 
 overrides:
-  form-data: ">=4.0.4"
+  form-data: ">=4.0.6"
   braces: ">=3.0.3"
   cross-spawn: ">=7.0.5"
   minimatch: ">=3.1.4"


### PR DESCRIPTION
Addresses a high-severity dev dependency vulnerability.

| Severity | Advisory | Package | Vulnerable | Fixed | Scope |
|---|---|---|---|---|---|
| high | GHSA-hmw2-7cc7-3qxx | form-data (transitive via jsdom > jest-environment-jsdom) | 4.0.5 | 4.0.6 | dev-only |

**Changes**: bumped existing pnpm override `form-data` from `>=4.0.4` to `>=4.0.6` in `pnpm-workspace.yaml`; lockfile updated.

**Validation**: `pnpm audit --audit-level high` clean (2 low remain), lint, typecheck, 55 tests, build all pass.

https://claude.ai/code/session_01P922wsRoNP5BwhCirmJU1P