### PR TITLE
fix: correct ESM/CJS package resolution (require/import both work)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,17 @@
   "version": "3.0.3",
   "description": "Tiny reactive engine for plain HTML and vanilla JavaScript",
   "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,7 @@
 import dts from "rollup-plugin-dts";
 import esbuild from "rollup-plugin-esbuild";
-import packageJson from "./package.json" with { type: "json" };
 
-const name = packageJson.main.replace(/\.js$/, "");
+const name = "dist/index";
 
 const bundle = (config) => ({
   ...config,
@@ -15,7 +14,7 @@ export default [
     plugins: [esbuild()],
     output: [
       {
-        file: `${name}.js`,
+        file: `${name}.cjs`,
         format: "cjs",
         sourcemap: true,
       },


### PR DESCRIPTION
## Problem
`package.json` sets `"type": "module"` but `main` pointed at `dist/index.js`, which rollup emits as **CommonJS** (`use strict`; `exports.…`). Under `type: module` Node parses any `.js` as ESM, so:
- `require("supastate")` and bare `import "supastate"` (which falls through to `main`, since there was no `exports` map) throw `ReferenceError: exports is not defined in ES module scope`.
- Bundler (Vite/webpack read `module` → `.mjs`) and CDN (`.mjs` imported explicitly) users were unaffected, which is why it went unnoticed.

## Fix
- Emit the CJS bundle as `dist/index.cjs` (unambiguous CommonJS regardless of `type`).
- Add a conditional `exports` map and point `main`/`module`/`types` through it.
- Add `sideEffects: false` for tree-shaking.

## Verified
Packed the tarball, installed it into a clean project, and ran both paths:
- `require("supastate")` → `reactive`/`text` are functions ✅
- `import { reactive, text } from "supastate"` → functions ✅
- `pnpm build`, `pnpm typecheck`, `pnpm lint` all pass.

https://claude.ai/code/session_01Be9Fxdq5NroabmT83VZuxs